### PR TITLE
Add FastAPI endpoints for playlist conversion

### DIFF
--- a/MonolithDev/gettingSongs/__init__.py
+++ b/MonolithDev/gettingSongs/__init__.py
@@ -1,4 +1,21 @@
+"""Package initialization for ``MonolithDev.gettingSongs``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Ensure the package directory is available on ``sys.path`` so that modules
+# imported from this package can use the existing absolute-style imports that
+# rely on being able to resolve siblings such as ``logging_config``.
+_PACKAGE_DIR = Path(__file__).resolve().parent
+if str(_PACKAGE_DIR) not in sys.path:
+    sys.path.append(str(_PACKAGE_DIR))
+
+
 # Initialize configuration on module import
-from config import init_config
+from config import init_config  # noqa: E402
 
 init_config()
+

--- a/MonolithDev/gettingSongs/api.py
+++ b/MonolithDev/gettingSongs/api.py
@@ -1,0 +1,122 @@
+"""FastAPI application exposing playlist conversion utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .get_playlist_songs import SpotifyPlaylistService
+from .playlist_pipeline import PlaylistPipeline
+from .youtube_utils import QueryType
+
+app = FastAPI(
+    title="AutoDJ Playlist Service",
+    description=(
+        "Endpoints for converting Spotify playlists and retrieving their tracks."
+    ),
+    version="1.0.0",
+)
+
+_pipeline = PlaylistPipeline()
+_spotify_service = SpotifyPlaylistService()
+
+
+class PlaylistConversionRequest(BaseModel):
+    """Input payload for launching the playlist conversion pipeline."""
+
+    playlist_url: str = Field(..., description="Spotify playlist URL or URI")
+    mixes_per_track: int = Field(
+        10,
+        ge=0,
+        description="Number of mix downloads to attempt per track.",
+    )
+    download_songs: bool = Field(
+        True, description="Whether to download the original tracks."
+    )
+    download_mixes: bool = Field(
+        True, description="Whether to download DJ mixes."
+    )
+
+
+class PlaylistConversionResponse(BaseModel):
+    """Response returned when a playlist conversion is triggered."""
+
+    playlist_id: str
+    total_tracks: int
+    playlist_json: Path
+    download_summaries: Dict[str, Dict]
+
+
+class PlaylistTracksResponse(BaseModel):
+    """Response containing track information for a Spotify playlist."""
+
+    playlist_id: str
+    total_tracks: int
+    tracks: List[Dict[str, object]]
+
+
+@app.post("/playlist/convert", response_model=PlaylistConversionResponse)
+async def convert_playlist(request: PlaylistConversionRequest) -> PlaylistConversionResponse:
+    """Trigger the AutoDJ pipeline for the provided Spotify playlist."""
+
+    try:
+        result = _pipeline.run(
+            request.playlist_url,
+            mixes_per_track=request.mixes_per_track,
+            download_songs=request.download_songs,
+            download_mixes=request.download_mixes,
+        )
+    except ValueError as exc:  # Validation or download errors surface as 400s
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    summaries = {
+        (query_type.value if isinstance(query_type, QueryType) else str(query_type)): summary
+        for query_type, summary in result.download_summaries.items()
+    }
+
+    return PlaylistConversionResponse(
+        playlist_id=result.playlist_id,
+        total_tracks=result.playlist.total,
+        playlist_json=result.playlist_json,
+        download_summaries=summaries,
+    )
+
+
+@app.get("/playlist/tracks", response_model=PlaylistTracksResponse)
+async def get_playlist_tracks(playlist_url: str) -> PlaylistTracksResponse:
+    """Return the tracks contained in the requested Spotify playlist."""
+
+    playlist = _spotify_service.fetch_playlist(playlist_url)
+    if playlist is None:
+        raise HTTPException(status_code=404, detail="Playlist not found or empty")
+
+    playlist_id = _spotify_service.extract_playlist_id(playlist_url)
+    tracks: List[Dict[str, object]] = []
+    for item in playlist.items:
+        if item.track is None:
+            continue
+        track = item.track
+        tracks.append(
+            {
+                "name": track.name,
+                "artists": [artist.name for artist in track.artists],
+                "album": track.album.name,
+                "duration_ms": track.duration_ms,
+                "duration": track.duration_formatted,
+                "explicit": track.explicit,
+                "preview_url": track.preview_url,
+                "spotify_url": (track.external_urls or {}).get("spotify"),
+                "spotify_uri": track.uri,
+                "spotify_id": track.id,
+                "added_at": item.added_at,
+            }
+        )
+
+    return PlaylistTracksResponse(
+        playlist_id=playlist_id,
+        total_tracks=playlist.total,
+        tracks=tracks,
+    )

--- a/MonolithDev/gettingSongs/playlist_full_converter.py
+++ b/MonolithDev/gettingSongs/playlist_full_converter.py
@@ -19,6 +19,11 @@ def parse_args() -> argparse.Namespace:
         description="Fetch a Spotify playlist and download its tracks and mixes."
     )
     parser.add_argument(
+        "playlist_url",
+        nargs="?",
+        help="Spotify playlist URL or URI to process.",
+    )
+    parser.add_argument(
         "--mixes-per-track",
         type=int,
         default=10,
@@ -66,7 +71,7 @@ def main() -> None:
     print("🎧 AutoDJ Playlist Pipeline")
     print("=" * 50)
 
-    playlist_url = get_playlist_url()
+    playlist_url = args.playlist_url or get_playlist_url()
 
     try:
         result = pipeline.run(

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,10 @@ pytest==7.4.4
 pytest-cov==4.1.0
 pytest-asyncio==0.23.2
 
+# Web API
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+
 # Spotify Integration
 spotipy==2.25.1
 python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- add a FastAPI application that exposes playlist conversion and track retrieval endpoints
- extend the playlist converter CLI to accept a playlist URL argument so it can run non-interactively
- ensure package imports resolve when used as a module and document the new FastAPI dependencies

## Testing
- python -m compileall MonolithDev/gettingSongs/api.py MonolithDev/gettingSongs/playlist_full_converter.py

------
https://chatgpt.com/codex/tasks/task_e_68d87e5b84148323a3cfb1e1baafa33a

## Summary by Sourcery

Introduce a FastAPI service for playlist conversion and track retrieval, extend the existing CLI to accept a playlist URL non-interactively, and update dependencies accordingly.

New Features:
- Expose a POST /playlist/convert endpoint to trigger the conversion pipeline with configurable options
- Expose a GET /playlist/tracks endpoint to retrieve track details from a Spotify playlist
- Extend the playlist converter CLI to accept an optional playlist URL argument for non-interactive execution

Build:
- Add fastapi and uvicorn to project dependencies in requirements.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a web API with endpoints to convert playlists and fetch track listings, including clear 400/404 error responses.
- Improvements
  - CLI now accepts an optional playlist URL argument; interactive prompt remains as a fallback.
- Chores
  - Updated dependencies to include web API server components.
  - Adjusted internal import handling to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->